### PR TITLE
issue #81: strongly reduced frame drops when using potis

### DIFF
--- a/mavc-target-agent/mavc-target-agent/Overlay.cs
+++ b/mavc-target-agent/mavc-target-agent/Overlay.cs
@@ -3,6 +3,7 @@ using System.Windows.Forms;
 using System.Runtime.InteropServices;
 using System.Drawing.Text;
 using System.Diagnostics;
+using System.Timers;
 
 public class Overlay : Form
 {
@@ -21,6 +22,10 @@ public class Overlay : Form
     private static int autoHideAfterSec = 1;
     private static bool hideIsActive = false;
     private static bool setbackHide = false;
+
+    private static int updateOverlayAfterMS = 100;
+    private static System.Timers.Timer checkForOverlayUpdate = new System.Timers.Timer(updateOverlayAfterMS);
+    private static bool needsOverlayUpdateToggler = true;
 
     public Overlay(int autoHideAfterSecs)
     {
@@ -51,6 +56,13 @@ public class Overlay : Form
         screenY = (screen.Height - barHeight) / 2; ;
 
         barArea = new Rectangle(screenX, screenY, barWidth, barHeight);
+
+        checkForOverlayUpdate.Elapsed += (sender, e) =>
+        {
+            needsOverlayUpdateToggler = true;
+        };
+
+        checkForOverlayUpdate.Start();
     }
 
     public void SetAutoHideActive(bool autoHideActive)
@@ -77,18 +89,23 @@ public class Overlay : Form
 
     public void setUpdatedVolume(String name,  int volume)
     {
-        volName = name;
-        volValue = volume;
-        this.Invalidate();
-
-        this.Invoke((Action)(() =>
+        if (needsOverlayUpdateToggler)
         {
-            this.Show();
-            this.Update();
-        }));
+            volName = name;
+            volValue = volume;
+            this.Invalidate();
 
-        if (autoHideActive && !hideIsActive)
-            AutoHideAsync(autoHideAfterSec);
+            this.Invoke((Action)(() =>
+            {
+                this.Show();
+                this.Update();
+            }));
+
+            if (autoHideActive && !hideIsActive)
+                AutoHideAsync(autoHideAfterSec);
+
+            needsOverlayUpdateToggler = false;
+        }
     }
 
     // activate Click-Through
@@ -120,7 +137,6 @@ public class Overlay : Form
     // Zeichnen
     protected override void OnPaint(PaintEventArgs e)
     {
-
         // Text-based Overlay
         e.Graphics.TextRenderingHint =
         TextRenderingHint.SingleBitPerPixelGridFit;


### PR DESCRIPTION
I strongly reduced the gpu drops when truning the knob (when the overlay is activated) by introducing a intervall-timed cap for the overlay refresh.